### PR TITLE
CI updates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,16 +15,16 @@ ci_template: &CI_TEMPLATE
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
+fedora39_task:
+  container:
+    # Fedora 39 EOL: Around Nov 2024
+    dockerfile: ci/fedora-39/Dockerfile
+  << : *CI_TEMPLATE
+
 fedora38_task:
   container:
     # Fedora 38 EOL: Around May 2024
     dockerfile: ci/fedora-38/Dockerfile
-  << : *CI_TEMPLATE
-
-fedora37_task:
-  container:
-    # Fedora 37 EOL: Around Dec 2024
-    dockerfile: ci/fedora-37/Dockerfile
   << : *CI_TEMPLATE
 
 centos7_task:
@@ -41,8 +41,14 @@ centosstream9_task:
 
 centosstream8_task:
   container:
-    # Stream 8 support should be 5 years, so until 2024. but I cannot find a concrete timeline --cpk
+    # Stream 8 EOL: May 31, 2024
     dockerfile: ci/centos-stream-8/Dockerfile
+  << : *CI_TEMPLATE
+
+debian12_task:
+  container:
+    # Debian 12 EOL: TBD
+    dockerfile: ci/debian-12/Dockerfile
   << : *CI_TEMPLATE
 
 debian11_task:
@@ -57,9 +63,15 @@ debian10_task:
     dockerfile: ci/debian-10/Dockerfile
   << : *CI_TEMPLATE
 
+opensuse_leap_15_5_task:
+  container:
+    # Opensuse Leap 15.5 EOL: Around Dec 25
+    dockerfile: ci/opensuse-leap-15.5/Dockerfile
+  << : *CI_TEMPLATE
+
 opensuse_leap_15_4_task:
   container:
-    # Opensuse Leap 15.4 EOL: TBD
+    # Opensuse Leap 15.4 EOL: Around Dec 23
     dockerfile: ci/opensuse-leap-15.4/Dockerfile
   << : *CI_TEMPLATE
 
@@ -84,38 +96,36 @@ ubuntu20_task:
 
 # Apple doesn't publish official long-term support timelines.
 # We aim to support both the current and previous macOS release.
+macos_sonoma_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-sonoma-base:latest
+  prepare_script: ./ci/macos/prepare.sh
+  << : *CI_TEMPLATE
+
 macos_ventura_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
 
-macos_monterey_task:
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-base:latest
-  prepare_script: ./ci/macos/prepare.sh
-  << : *CI_TEMPLATE
-
 # FreeBSD EOL timelines: https://www.freebsd.org/security/#sup
 freebsd14_task:
   freebsd_instance:
-    # We don't support FreeBSD 14 yet, this is a purely informative task
-    image_family: freebsd-14-0-snap
-    allow_failures: true
-    skip_notification: true
+    # FreeBSD 14 EOL: Nov 30 2028
+    image_family: freebsd-14-0
   prepare_script: ./ci/freebsd/prepare.sh
   << : *CI_TEMPLATE
 
 freebsd13_task:
   freebsd_instance:
-    # FreeBSD 13.1 EOL: TBD (13.2 + 3 months)
+    # FreeBSD 13 EOL: January 31, 2026
     image_family: freebsd-13-2
   prepare_script: ./ci/freebsd/prepare.sh
   << : *CI_TEMPLATE
 
 freebsd12_task:
   freebsd_instance:
-    # FreeBSD 12 EOL: June 30, 2024
-    image_family: freebsd-12-2
+    # FreeBSD 12 EOL: Dec 31, 2023
+    image_family: freebsd-12-4
   prepare_script: ./ci/freebsd/prepare.sh
   << : *CI_TEMPLATE

--- a/ci/debian-12/Dockerfile
+++ b/ci/debian-12/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:12
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20231213
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+RUN apt-get update && apt-get -y install \
+    cmake \
+    g++ \
+    git \
+    libpcap-dev \
+    make \
+    python3 \
+    python3-pip\
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install btest

--- a/ci/fedora-39/Dockerfile
+++ b/ci/fedora-39/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:37
+FROM fedora:39
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230823
+ENV DOCKERFILE_VERSION 20231213
 
 RUN dnf -y install \
     cmake \

--- a/ci/opensuse-leap-15.5/Dockerfile
+++ b/ci/opensuse-leap-15.5/Dockerfile
@@ -1,0 +1,28 @@
+FROM opensuse/leap:15.5
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20231213
+
+RUN zypper refresh \
+ && zypper in -y \
+    cmake \
+    gcc10 \
+    gcc10-c++ \
+    git \
+    gzip \
+    libpcap-devel \
+    make \
+    python39 \
+    python39-devel \
+    python39-pip \
+    tar \
+    which \
+  && rm -rf /var/cache/zypp
+
+RUN update-alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.9 100
+
+RUN pip3 install btest
+
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 100
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 100


### PR DESCRIPTION
 - Remove Fedora 37, add 39
 - Add openSUSE Leap 15.5
 - Add Debian 12
 - Remove macOS Monterey, add Sonoma
 - Take FreeBSD 14 out of test-only mode, bump 12.2 to 12.4